### PR TITLE
Improve the documentation about how to use ov as a pager in git or in git when using delta

### DIFF
--- a/content/ov/delta.en.md
+++ b/content/ov/delta.en.md
@@ -2,7 +2,7 @@
 author: "Noboru Saito"
 title: "delta"
 description: "ov can also be used as a pager for delta."
-date: 2022-09-27T18:00:00+09:00
+date: 2024-02-25T18:00:00+09:00
 tags: ["ov", "git", "delta"]
 categories: ["ov"]
 weight: 3
@@ -17,22 +17,41 @@ This is an example of gitconfig settings.
 
 ```gitconfig
 [core]
-    pager = delta
+    # delta will used as the default pager for git
+    # and ov as the default pager for delta
+    # the pager will be overloaded via the [pager] section for a few commands
+    pager = delta --pager='ov -F'
+
+[pager]
+    # overload delta pager for some commands
+    show = delta --pager='ov -F --header 3'
+
+    # We are now overloading some commands via "delta features"
+    # This allows us to use different pager per git command
+    # It allows to maintain a simpler config file and avoid escaping quotes
+    diff = delta --features ov-diff
+    log  = delta --features ov-log
 
 [delta]
     navigate = true
     side-by-side = true
     file-style = yellow
+
+# we define the delta feature "ov-diff" we are using for git diff
+[delta "ov-diff"]
+    # the idea is to overload the pager used by delta when using git diff
+    # we are using the same pattern used by delta when the default pager (less) is used
+    # using ov section feature brings a better experience
+    pager=ov -F --section-delimiter '^(commit|added:|removed:|renamed:|Δ)' --section-header --pattern '•'
+
+# we define the delta feature "ov-log" we are using for git log
+[delta "ov-log"]
+    # the idea is to overload the pager used by delta when using git log
+    # using ov section feature brings a better experience
+    pager=ov -F --section-delimiter '^commit' --section-header-num 3
 ```
 
-`navigate = true` of `delta` is set to allow you to move in diff units using the `n/N` keys of `less`.
-This setting allows you to mark the necessary locations.
-
-Use that mark to set `ov`` with environment variables.
-
-```env
-export DELTA_PAGER="ov --section-delimiter '^(commit|added:|removed:|renamed:|Δ)' --section-header --pattern '•'"
-```
+This setting allows you to mark the necessary locations as section for `ov` when using `delta`.
 
 By combining these settings, you can move files by file (`space` key of `^` key) and diff by `n/N` key.
 

--- a/content/ov/git.en.md
+++ b/content/ov/git.en.md
@@ -2,8 +2,8 @@
 author: "Noboru Saito"
 title: "git"
 description: "Use ov as a pager for git"
-date: 2023-12-30T15:00:00+09:00
-tags: ["ov"]
+date: 2024-02-26T07:00:00+09:00
+tags: ["ov", "git"]
 categories: ["ov"]
 weight: 2
 ---
@@ -15,6 +15,9 @@ Also, it is recommended to set the jump-target to "section" accordingly.
 It is recommended to set the following in gitconfig.
 
 ```config
+[core]
+    pager = "ov -F"
+
 [pager]
     diff = "ov -F --section-delimiter '^diff' --section-header"
     log = "ov -F --section-delimiter '^commit' --section-header-num 3"

--- a/content/ov/git.en.md
+++ b/content/ov/git.en.md
@@ -21,6 +21,7 @@ It is recommended to set the following in gitconfig.
 [pager]
     diff = "ov -F --section-delimiter '^diff' --section-header"
     log = "ov -F --section-delimiter '^commit' --section-header-num 3"
+    show = "ov -F --header 3"
 ```
 
 (Please add `--jump-target "section"` if you like)

--- a/content/ov/git.ja.md
+++ b/content/ov/git.ja.md
@@ -22,6 +22,7 @@ gitの出力をセクション区切りで分割することで、より使い�
 [pager]
     diff = "ov -F --section-delimiter '^diff' --section-header"
     log = "ov -F --section-delimiter '^commit' --section-header-num 3"
+    show = "ov -F --header 3"
 ```
 
 （`--jump-target "section"`はお好みで追加してください）

--- a/content/ov/git.ja.md
+++ b/content/ov/git.ja.md
@@ -2,8 +2,8 @@
 author: "Noboru Saito"
 title: "git"
 description: "gitのページャーとしてovを使用する"
-date: 2023-12-30T15:00:00+09:00
-tags: ["ov"]
+date: 2024-02-25T18:00:00+09:00
+tags: ["ov", "git"]
 categories: ["ov"]
 weight: 2
 ---
@@ -16,6 +16,9 @@ gitの出力をセクション区切りで分割することで、より使い�
 以下はgitの推奨設定例です。
 
 ```config
+[core]
+    pager = "ov -F"
+
 [pager]
     diff = "ov -F --section-delimiter '^diff' --section-header"
     log = "ov -F --section-delimiter '^commit' --section-header-num 3"


### PR DESCRIPTION
Update documentation to improve ov integration in git when using delta

The previous documentation was bringing a bug when navigating in git log or when using git show

Note: Only the English documentation page for delta was updated.
The Japanese one will need to be updated accordingly in a dedicated commit.

Fixes #2 


Another commit allow using ov as the default pager for all git commands, and not only for git diff and git log.

ov will now be used for any command like these:
- git blame
- git relog
- git show
- git stash list
...


We also improve the integration of ov with git show by allowing to keep the first three lines as a header

