### PR TITLE
fix(ov): psql env var examples missing '='

### DIFF
--- a/content/ov/psql.en.md
+++ b/content/ov/psql.en.md
@@ -20,7 +20,7 @@ It is also recommended to change the color of the columns(`--column-rainbow`).
 The `--align` option added in v0.37.0 can also be used to shrink columns.
 
 ```env
-PSQL_PAGER 'ov -F -C -d "|" -H1 --column-rainbow --align'
+PSQL_PAGER='ov -F -C -d "|" -H1 --column-rainbow --align'
 ```
 
 The following sets the header style of `config.yaml`.
@@ -45,7 +45,7 @@ This is the recommended value for `PSQL_WATCH_PAGER`.
 Continues to display the last section separated by blank lines.
 
 ```env
-PSQL_WATCH_PAGER 'ov --follow-section --section-delimiter "^$"'
+PSQL_WATCH_PAGER='ov --follow-section --section-delimiter "^$"'
 ```
 
 ![watch](/ov/ov-psql-watch.gif)

--- a/content/ov/psql.ja.md
+++ b/content/ov/psql.ja.md
@@ -59,7 +59,7 @@ PSQL_WATCH_PAGER='ov --follow-section --section-delimiter "^$"'
 拡張出力（\x）で表示のときには、レコード区切りをセクション区切りとして扱うと、レコード区切りでスクロールするため、見やすくなります。以下のコマンドで拡張出力モードを有効にできます。
 
 ```env
-PAGER 'ov -F --section-delimiter "^-"'
+PAGER='ov -F --section-delimiter "^-"'
 ```
 
 ![\x](/ov/ov-psql-vf.gif)


### PR DESCRIPTION
Stumbled upon these missing `=` in the code samples.

BTW: 
**ov** is brilliant!

Thank you! 🙏 